### PR TITLE
fix: activity display for newly added expenses

### DIFF
--- a/app/(tabs)/activity.tsx
+++ b/app/(tabs)/activity.tsx
@@ -1,6 +1,7 @@
 import { View, Text, FlatList, StyleSheet, RefreshControl } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { getAllGroups, getGroupExpenses, getGroupMember, Expense } from '../../services/groupRepository';
 import { formatNumber } from '../../utils/money';
 
@@ -38,9 +39,11 @@ export default function ActivityScreen() {
     setRefreshing(false);
   }, []);
 
-  useEffect(() => {
-    loadActivities();
-  }, [loadActivities]);
+  useFocusEffect(
+    useCallback(() => {
+      loadActivities();
+    }, [loadActivities])
+  );
 
   const onRefresh = () => {
     setRefreshing(true);


### PR DESCRIPTION
The “Activity” screen didn’t display activity for recently added expenses. The activity for these expenses was displayed correctly after restarting the app, but not right after they were added. This PR fixes the problem.
