### PR TITLE
feat: use trash bin instead of button for group member removal

### DIFF
--- a/app/group/[id]/edit-member.tsx
+++ b/app/group/[id]/edit-member.tsx
@@ -326,7 +326,22 @@ export default function EditMemberScreen() {
           <ArrowLeft color="#111827" size={24} />
         </TouchableOpacity>
         <Text style={styles.title}>Edit Member</Text>
-        <View style={styles.placeholder} />
+        {(isCurrentUserMember || (canDelete && !checkingDelete)) && (
+          <TouchableOpacity
+            onPress={handleDeleteMember}
+            style={[
+              styles.deleteIconButton,
+              loading && styles.deleteIconButtonDisabled,
+            ]}
+            disabled={loading}
+          >
+            <Trash2 color="#dc2626" size={20} />
+          </TouchableOpacity>
+        )}
+        {!isCurrentUserMember && !canDelete && !checkingDelete && (
+          <View style={styles.placeholder} />
+        )}
+        {checkingDelete && <View style={styles.placeholder} />}
       </View>
 
       <KeyboardAvoidingView
@@ -393,29 +408,6 @@ export default function EditMemberScreen() {
                   : 'Update Member'}
             </Text>
           </TouchableOpacity>
-
-          {(isCurrentUserMember || (canDelete && !checkingDelete)) && (
-            <TouchableOpacity
-              style={[
-                styles.deleteButton,
-                loading && styles.deleteButtonDisabled,
-              ]}
-              onPress={handleDeleteMember}
-              disabled={loading}
-            >
-              <Trash2 color="#dc2626" size={20} />
-              <Text style={styles.deleteButtonText}>
-                {isCurrentUserMember ? 'Leave Group' : 'Remove from Group'}
-              </Text>
-            </TouchableOpacity>
-          )}
-
-          {!isCurrentUserMember && !canDelete && !checkingDelete && (
-            <Text style={styles.deleteHint}>
-              This member cannot be removed. Members involved in any expenses
-              cannot be deleted.
-            </Text>
-          )}
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -438,6 +430,12 @@ const styles = StyleSheet.create({
   },
   backButton: {
     padding: 4,
+  },
+  deleteIconButton: {
+    padding: 4,
+  },
+  deleteIconButtonDisabled: {
+    opacity: 0.4,
   },
   title: {
     fontSize: 20,
@@ -504,32 +502,5 @@ const styles = StyleSheet.create({
     color: '#ffffff',
     fontSize: 16,
     fontWeight: '600',
-  },
-  deleteButton: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#ffffff',
-    padding: 16,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#dc2626',
-    marginTop: 12,
-    gap: 8,
-  },
-  deleteButtonDisabled: {
-    opacity: 0.5,
-  },
-  deleteButtonText: {
-    color: '#dc2626',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  deleteHint: {
-    fontSize: 13,
-    color: '#6b7280',
-    marginTop: 12,
-    textAlign: 'center',
-    lineHeight: 18,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10910,9 +10910,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -14457,9 +14457,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
In the 'Edit Member' screen, replace the bottom 'Remove Member' button with a small trash bin icon on the top-right. This keeps consistency with expense/transfer removal and separates destructive action from typical workflow