### PR TITLE
feat: disable create button during member addition and improve keyboard handling

### DIFF
--- a/app/create-group.tsx
+++ b/app/create-group.tsx
@@ -250,8 +250,8 @@ export default function CreateGroupScreen() {
 
       <KeyboardAvoidingView
         style={styles.keyboardAvoidingView}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
       >
         <View style={styles.scrollContainer}>
           <ScrollView
@@ -480,10 +480,10 @@ export default function CreateGroupScreen() {
           <TouchableOpacity
             style={[
               styles.createButton,
-              creating && styles.createButtonDisabled,
+              (creating || showAddMember) && styles.createButtonDisabled,
             ]}
             onPress={handleCreate}
-            disabled={creating}
+            disabled={creating || showAddMember}
           >
             <Text style={styles.createButtonText}>
               {creating ? 'Creating...' : 'Create Group'}

--- a/app/create-group.tsx
+++ b/app/create-group.tsx
@@ -51,8 +51,9 @@ export default function CreateGroupScreen() {
     selectCurrency,
     loading: currenciesLoading,
   } = useCurrencyOrder();
-  const controlsDisabled = creating || addingMember || showAddMember;
-  const addMemberControlsDisabled = controlsDisabled || currentUserLoading;
+  const asyncInFlight = creating || addingMember || currentUserLoading;
+  const addMemberControlsDisabled = asyncInFlight;
+  const createButtonDisabled = asyncInFlight || showAddMember;
 
   const loadCurrentUser = useCallback(async () => {
     setCurrentUserLoading(true);
@@ -177,7 +178,7 @@ export default function CreateGroupScreen() {
   };
 
   const handleCreate = async () => {
-    if (controlsDisabled) {
+    if (createButtonDisabled) {
       return;
     }
 
@@ -234,7 +235,7 @@ export default function CreateGroupScreen() {
         <TouchableOpacity
           onPress={() => router.back()}
           style={styles.closeButton}
-          disabled={controlsDisabled}
+          disabled={asyncInFlight}
         >
           <X color="#111827" size={24} />
         </TouchableOpacity>
@@ -246,7 +247,7 @@ export default function CreateGroupScreen() {
         style={styles.keyboardAvoidingView}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
-        pointerEvents={controlsDisabled ? 'none' : 'auto'}
+        pointerEvents={asyncInFlight ? 'none' : 'auto'}
       >
         <View style={styles.scrollContainer}>
           <ScrollView
@@ -264,7 +265,7 @@ export default function CreateGroupScreen() {
                 onBlur={() => setGroupName((name) => name.trim())}
                 placeholder="e.g., Trip to Paris"
                 placeholderTextColor="#9ca3af"
-                editable={!controlsDisabled}
+                editable={!asyncInFlight}
               />
             </View>
 
@@ -421,10 +422,10 @@ export default function CreateGroupScreen() {
           <TouchableOpacity
             style={[
               styles.createButton,
-              controlsDisabled && styles.createButtonDisabled,
+              createButtonDisabled && styles.createButtonDisabled,
             ]}
             onPress={handleCreate}
-            disabled={controlsDisabled}
+            disabled={createButtonDisabled}
           >
             <Text style={styles.createButtonText}>
               {creating


### PR DESCRIPTION
Fixes #44

This PR improves the member addition experience in the "Create Group" screen by:

1. **Disabling the "Create Group" button during member addition**: The button is now disabled when the member addition form is active, preventing accidental group creation.

2. **Fixing keyboard overlap**: Adjusted KeyboardAvoidingView configuration to ensure the keyboard doesn't overlap with member addition fields on both iOS and Android.

### Changes
- Updated `app/create-group.tsx` to disable the Create Group button when `showAddMember` is true
- Adjusted KeyboardAvoidingView behavior and offset for better keyboard handling

Generated with [Claude Code](https://claude.ai/code)