### PR TITLE
fix: allow single-tap confirmation of display name change

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   Modal,
   ActivityIndicator,
+  Keyboard,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState, useEffect, useCallback } from 'react';
@@ -49,6 +50,7 @@ export default function SettingsScreen() {
   }, [loadUserProfile]);
 
   const handleSaveName = async () => {
+    Keyboard.dismiss();
     if (!user?.id || !tempName.trim()) return;
 
     try {


### PR DESCRIPTION
Add Keyboard.dismiss() to handleSaveName() to programmatically dismiss the keyboard before saving. This fixes the issue where tapping the green confirmation button while the input field is focused required two taps (first to unfocus, second to confirm).

Fixes #69

Generated with [Claude Code](https://claude.ai/code)