### PR TITLE
fix: restrict RLS SELECT policy on users table to own row only

### DIFF
--- a/services/groupRepository.ts
+++ b/services/groupRepository.ts
@@ -101,20 +101,23 @@ export async function getUser(userId: string): Promise<User | null> {
 
 export async function getUserByEmail(email: string): Promise<User | null> {
   try {
-    const { data, error } = await supabase
-      .from('users')
-      .select('*')
-      .eq('email', email)
-      .maybeSingle();
+    const { data, error } = await supabase.functions.invoke('get-user-by-email', {
+      body: { email },
+    });
 
     if (error) throw error;
-    if (!data) return null;
+    if (!data?.success) {
+      throw new Error('Edge function returned unsuccessful response');
+    }
+
+    const user = data.user;
+    if (!user) return null;
 
     return {
-      id: data.id,
-      name: data.name,
-      email: data.email || undefined,
-      createdAt: data.created_at,
+      id: user.id,
+      name: user.name,
+      email: user.email || undefined,
+      createdAt: user.createdAt,
     };
   } catch (error) {
     console.error('Failed to get user by email:', error);

--- a/supabase/functions/get-user-by-email/index.ts
+++ b/supabase/functions/get-user-by-email/index.ts
@@ -1,0 +1,139 @@
+import 'jsr:@supabase/functions-js@2/edge-runtime.d.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2.58.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, X-Client-Info, Apikey',
+};
+
+interface GetUserByEmailRequest {
+  email: string;
+}
+
+interface User {
+  id: string;
+  name: string;
+  email?: string;
+  createdAt: string;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 200,
+      headers: corsHeaders,
+    });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    // Create admin client with service role key (bypasses RLS)
+    const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    // Validate user token
+    const token = authHeader.replace('Bearer ', '');
+    const {
+      data: { user },
+      error: userError,
+    } = await supabaseAdmin.auth.getUser(token);
+
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Parse request body
+    const { email }: GetUserByEmailRequest = await req.json();
+
+    if (!email) {
+      return new Response(
+        JSON.stringify({
+          error: 'Missing required field: email',
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    // Fetch user by email using service role (bypasses RLS)
+    const { data: userData, error: fetchError } = await supabaseAdmin
+      .from('users')
+      .select('*')
+      .eq('email', email)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error('Failed to fetch user by email:', fetchError);
+      return new Response(
+        JSON.stringify({
+          error: 'Failed to fetch user',
+        }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    if (!userData) {
+      return new Response(JSON.stringify({ success: true, user: null }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const user_result: User = {
+      id: userData.id,
+      name: userData.name,
+      email: userData.email || undefined,
+      createdAt: userData.created_at,
+    };
+
+    return new Response(JSON.stringify({ success: true, user: user_result }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Error in get-user-by-email function:', error);
+    return new Response(
+      JSON.stringify({
+        error: 'Internal server error',
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    );
+  }
+});

--- a/supabase/migrations/20260208222441_restrict_users_select_to_own_row.sql
+++ b/supabase/migrations/20260208222441_restrict_users_select_to_own_row.sql
@@ -1,0 +1,30 @@
+/*
+  # Restrict SELECT on users table to own row only
+
+  ## Summary
+  Updates the RLS policy for SELECT operations on the users table to only allow
+  authenticated users to read their own user record (where id = auth.uid()).
+
+  ## Changes
+  - Drops the existing "Authenticated users can read all users" policy
+  - Creates a new policy that restricts SELECT to only the authenticated user's own row
+
+  ## Security
+  - Users can only SELECT their own user record (where (select auth.uid()) = id)
+  - The getUserByEmail functionality is moved to the get-user-by-email edge function
+    which uses service role access to fetch user data by email
+  - This prevents arbitrary email enumeration by authenticated users
+
+  ## Related
+  - Edge function: supabase/functions/get-user-by-email/index.ts
+*/
+
+-- Drop the existing policy that allows reading all users
+DROP POLICY IF EXISTS "Authenticated users can read all users" ON public.users;
+
+-- Create a new policy that only allows reading own user record
+CREATE POLICY "Users can read their own record"
+  ON public.users
+  FOR SELECT
+  TO authenticated
+  USING ((select auth.uid()) = id);


### PR DESCRIPTION
This change prevents authenticated users from arbitrarily querying all user emails from the database by restricting the SELECT policy on the users table to only allow reading one's own user record.

## Changes
- Add get-user-by-email edge function with service role access for fetching user data by email (required for member connection flows)
- Add migration to restrict users SELECT policy to own row only
- Update getUserByEmail() to call the new edge function instead of direct database query

Closes #67

Generated with [Claude Code](https://claude.ai/code)